### PR TITLE
Deleting blank lines at the beginning of the CSV file

### DIFF
--- a/_data/readinglist.csv
+++ b/_data/readinglist.csv
@@ -1,5 +1,3 @@
-
-
 book,creator
 The Faraway Tree Collection,Enid Blyton
 A mid summer night's dream,William Shakespeare


### PR DESCRIPTION
Hi @gitsgulabjamun 

I changed the `readinglist.csv` file, which had a syntax error. I deleted the blank lines at the beginning of the file. The data is now getting pulled correctly. You can see the rendered book list here: [https://aninditabasu.github.io/SunilWebsite/](https://aninditabasu.github.io/SunilWebsite/). 

**Please accept this pull request.**  After you accept this pull request, my changes will be copied over to your repository, and you website will also show the books list. (It doesn't at the moment) 
![image](https://user-images.githubusercontent.com/12574108/112430435-28760000-8d64-11eb-9bb8-7df57d5815ca.png)
